### PR TITLE
Add tests for lyric tokenization and audio IO fallbacks

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -17,8 +17,6 @@ Unit Testing TODOs (new features)
 - lyrics.py: LRCLIB integration
   - Mock HTTP for /get (spotifyId) and /search; duration windowing logic.
   - Ensure graceful fallback on network/API errors.
-- lyrics.py: to_rb_tokens
-  - Trailing '-' on non-final syllables only; punctuation preserved.
 - mid_vocals.py: write_vocals_midi
   - Generates PART VOCALS track with lyric meta + talky notes.
   - Phrase markers ordering and boundaries; tempo/ticks math sanity.
@@ -28,7 +26,6 @@ Unit Testing TODOs (new features)
   - No crash if lyrics unavailable; still exports chart.
 
 - audio_io.py: ffmpeg-based loader + duration helper
-  - Mocked runs with/without ffmpeg/ffprobe in PATH; fallback to librosa.
   - Decode mono/stereo; resample to requested `sr`; dtype/shape invariants.
   - get_duration cross-check vs librosa within tolerance; error paths on non-audio files.
 - main.py: BPM estimation with `librosa.feature.rhythm.tempo`

--- a/tests/inference/test_lyrics.py
+++ b/tests/inference/test_lyrics.py
@@ -1,0 +1,21 @@
+import pytest
+from chart_hero.inference.lyrics import Syllable, Word, Line, to_rb_tokens
+
+
+def make_line():
+    syllables = [
+        Syllable(text="hel", t0=0.0, t1=0.25),
+        Syllable(text="lo,", t0=0.25, t1=0.5),
+    ]
+    word1 = Word(text="hello,", t0=0.0, t1=0.5, syllables=syllables)
+    word2 = Word(text="world", t0=0.5, t1=1.0, syllables=[
+        Syllable(text="world", t0=0.5, t1=1.0)
+    ])
+    line = Line(text="hello, world", t0=0.0, t1=1.0, words=[word1, word2])
+    return [line]
+
+
+def test_to_rb_tokens_trailing_dash_and_punctuation():
+    lines = make_line()
+    tokens = [tok for _, tok in to_rb_tokens(lines)]
+    assert tokens == ["hel-", "lo,", "world"]

--- a/tests/utils/test_audio_io.py
+++ b/tests/utils/test_audio_io.py
@@ -1,0 +1,53 @@
+import numpy as np
+from chart_hero.utils import audio_io
+
+
+class DummyProc:
+    def __init__(self, data: bytes):
+        self.stdout = data
+
+
+def test_load_audio_ffmpeg(monkeypatch):
+    data = np.array([0.1, 0.2], dtype=np.float32).tobytes()
+
+    def fake_run(cmd, check, stdout):
+        return DummyProc(data)
+
+    monkeypatch.setattr(audio_io, "has_ffmpeg", lambda: True)
+    monkeypatch.setattr(audio_io.subprocess, "run", fake_run)
+
+    y, sr = audio_io.load_audio("dummy.wav", sr=22050, mono=True)
+    assert sr == 22050
+    assert np.allclose(y, np.array([0.1, 0.2], dtype=np.float32))
+
+
+def test_load_audio_fallback_to_librosa(monkeypatch):
+    expected = np.array([0.3, 0.4], dtype=np.float32)
+
+    def fake_load(path, sr=None, mono=True):
+        return expected, 44100
+
+    monkeypatch.setattr(audio_io, "has_ffmpeg", lambda: False)
+    monkeypatch.setattr(audio_io.librosa, "load", fake_load)
+
+    y, sr = audio_io.load_audio("dummy.wav")
+    assert sr == 44100
+    assert np.allclose(y, expected)
+
+
+def test_get_duration_ffprobe(monkeypatch):
+    monkeypatch.setattr(audio_io, "has_ffprobe", lambda: True)
+
+    def fake_check_output(cmd, text):
+        return "1.23"
+
+    monkeypatch.setattr(audio_io.subprocess, "check_output", fake_check_output)
+    dur = audio_io.get_duration("dummy.wav")
+    assert dur == 1.23
+
+
+def test_get_duration_fallback(monkeypatch):
+    monkeypatch.setattr(audio_io, "has_ffprobe", lambda: False)
+    monkeypatch.setattr(audio_io.librosa, "get_duration", lambda path: 2.34)
+    dur = audio_io.get_duration("dummy.wav")
+    assert dur == 2.34


### PR DESCRIPTION
## Summary
- test lyrics to_rb_tokens preserves punctuation and hyphenation
- add audio IO tests for ffmpeg and librosa/ffprobe fallbacks
- trim completed items from TECH_DEBT tracker

## Testing
- `pytest tests/inference/test_lyrics.py tests/utils/test_audio_io.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdebeccc708323bbb96a7c3fe967f4