### PR TITLE
Ensure pro-cymbal toggles precede drum gems

### DIFF
--- a/src/chart_hero/model_training/transformer_config.py
+++ b/src/chart_hero/model_training/transformer_config.py
@@ -280,7 +280,10 @@ class LocalConfig(BaseConfig):
     max_seq_len: int = 512  # Reduced from 768
 
     def __post_init__(self) -> None:
-        if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+        """Select default device preferring MPS, then CUDA, otherwise CPU."""
+        # `torch.backends.mps.is_built` is not consistently available across builds;
+        # checking only `is_available` keeps logic simple and testable.
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
             self.device = "mps"
         elif torch.cuda.is_available():
             self.device = "cuda"


### PR DESCRIPTION
## Summary
- fix event sorting so cymbal/tom toggles occur before drum gems in exported MIDI
- test pro-cymbal toggle ordering and default state
- respect max_seq_len when cropping spectrograms and prefer MPS in LocalConfig
- simplify CLI song identification and compute song duration lazily

## Testing
- `pytest tests/model_training/test_data_preparation.py::test_data_preparation -q`
- `pytest tests/model_training/test_transformer_config.py::test_local_config_device_mps_selected -q`
- `pytest tests/model_training/test_transformer_config.py::test_local_config_device_mps_preferred_over_cuda -q`
- `pytest tests/model_training/test_transformer_data.py::test_data_loading -q`
- `pytest tests/test_cli.py::test_main -q`
- `pytest` *(fails: tests/inference/test_charter.py::test_chart_generator, tests/inference/test_input_transform.py::test_audio_to_tensors, tests/inference/test_validation_and_packaging.py::test_write_chart_and_validate, tests/model_training/test_augment_audio.py::test_augment_pitch, tests/model_training/test_data_integrity.py::test_data_pipeline_integrity)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf6b815e483239cd6479be2740d6d