### PR TITLE
Skip drumless MIDI charts

### DIFF
--- a/src/chart_hero/utils/rb_midi_utils.py
+++ b/src/chart_hero/utils/rb_midi_utils.py
@@ -81,8 +81,8 @@ class RbMidiProcessor:
 
         label = torch.zeros((num_time_frames, len(TARGET_CLASSES)), dtype=torch.float32)
         if active is None:
-            # No gem notes found; return empty labels
-            return label
+            # No Expert-difficulty drum gems found; skip this chart
+            return None
 
         start = diff_start[active]
 

--- a/tests/utils/test_rb_midi_utils.py
+++ b/tests/utils/test_rb_midi_utils.py
@@ -33,3 +33,11 @@ def test_rb_midi_processor_on_rb2_mid(config):
     assert labels.shape == (frames, config.num_drum_classes)
     # Expect some drum content
     assert torch.sum(labels) > 0
+
+
+def test_rb_midi_processor_returns_none_when_no_drums(config):
+    midi_path = Path("tests/assets/dummy_data/dummy_0.mid")
+    proc = RbMidiProcessor(config)
+    frames = int(10 * (config.sample_rate / config.hop_length))
+    labels = proc.create_label_matrix(midi_path, frames)
+    assert labels is None


### PR DESCRIPTION
## Summary
- ensure MIDI label extraction returns `None` for charts without any Expert drum gems
- add regression test for drumless charts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be048e46a4832392cc8ca4499df1e6