### PR TITLE
Streamline inference and MIDI export logic

### DIFF
--- a/src/chart_hero/model_training/training_setup.py
+++ b/src/chart_hero/model_training/training_setup.py
@@ -16,6 +16,11 @@ from pytorch_lightning.callbacks import (
     LearningRateMonitor,
     ModelCheckpoint,
 )
+
+try:  # pragma: no-cover - optional dependency
+    from pytorch_lightning.loggers import WandbLogger  # type: ignore
+except ModuleNotFoundError:  # pragma: no-cover
+    WandbLogger = None  # type: ignore[assignment]
 from chart_hero.model_training.transformer_config import (
     BaseConfig,
     auto_detect_config,
@@ -248,10 +253,7 @@ def setup_logger(
 ) -> object | None:
     if not use_wandb:
         return None
-    try:
-        from pytorch_lightning.loggers import WandbLogger
-        import wandb  # noqa: F401  # ensure wandb is available
-    except ModuleNotFoundError:
+    if WandbLogger is None:
         logger.warning("wandb is not installed; disabling W&B logging")
         return None
     return WandbLogger(


### PR DESCRIPTION
## Summary
- clarify device selection and keep spectrograms as tensors for efficient padding
- vectorize pitch mapping and pre-compute sample-to-tick scaling in MIDI export
- expose `WandbLogger` stub so tests can patch training setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be32318c3483238554de15dc807b77