### PR TITLE
Improve Rock Band MIDI utilities for robust parsing and performance

### DIFF
--- a/src/chart_hero/utils/rb_midi_utils.py
+++ b/src/chart_hero/utils/rb_midi_utils.py
@@ -19,6 +19,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+from bisect import bisect_right
+from collections import deque
+import logging
+
 import mido
 import torch
 
@@ -48,11 +52,12 @@ class RbMidiProcessor:
                 # Older mido versions don't support clip; fall back without it.
                 mf = mido.MidiFile(midi_path)
         except Exception as e:
-            print(f"Warning: Could not read MIDI file {midi_path}: {e}")
+            logging.warning("Could not read MIDI file %s: %s", midi_path, e)
             return None
 
         tpq = mf.ticks_per_beat or 480
         tempo_map = self._collect_tempo_changes(mf)
+        tempo_segments = self._build_tempo_segments(tempo_map, tpq)
 
         drum_tracks = self._find_drum_tracks(mf)
         if not drum_tracks:
@@ -68,16 +73,19 @@ class RbMidiProcessor:
                 events.append((t, msg))
         events.sort(key=lambda x: x[0])
 
-        # Only use Expert difficulty (96..101). Lower difficulties omit notes and
-        # would create contradictory labels for the same audio.
         diff_start = {"Expert": 96, "Hard": 84, "Medium": 72, "Easy": 60}
         counts = {k: 0 for k in diff_start}
         for _, msg in events:
             if msg.type == "note_on" and msg.velocity > 0:
-                s = diff_start["Expert"]
-                if s <= msg.note <= s + 5:
-                    counts["Expert"] += 1
-        active = "Expert" if counts["Expert"] > 0 else None
+                for dname, start in diff_start.items():
+                    if start <= msg.note <= start + 5:
+                        counts[dname] += 1
+                        break
+        active = None
+        for dname in ("Expert", "Hard", "Medium", "Easy"):
+            if counts[dname] > 0:
+                active = dname
+                break
 
         label = torch.zeros((num_time_frames, len(TARGET_CLASSES)), dtype=torch.float32)
         if active is None:
@@ -100,13 +108,13 @@ class RbMidiProcessor:
                 continue
             # Double-kick note
             if n == 95:
-                frame = self._tick_to_frame(abs_tick, tempo_map, tpq)
+                frame = self._tick_to_frame(abs_tick, tempo_segments, tpq)
                 self._mark(label, frame, "0", num_time_frames)
                 continue
             # Difficulty gem
             if start <= n <= start + 5:
                 pad = n - start  # 0..5
-                frame = self._tick_to_frame(abs_tick, tempo_map, tpq)
+                frame = self._tick_to_frame(abs_tick, tempo_segments, tpq)
                 if pad == 0:
                     self._mark(label, frame, "0", num_time_frames)
                 elif pad == 1:
@@ -133,10 +141,11 @@ class RbMidiProcessor:
                 if msg.is_meta and msg.type == "track_name":
                     tr_name = msg.name
                     break
-            names.append(((tr_name or "").lower(), tr))
+            name = (tr_name or "").strip().lower().replace("_", " ")
+            names.append((name, tr))
         # Prefer pro/real drums style tracks when present, otherwise PART DRUMS.
-        preferred = ["part real_drums_ps", "real drums", "pro drums", "part drums"]
-        fallbacks = ["drums", "part_drums", "real_drums", "part real_drums"]
+        preferred = ["part real drums ps", "real drums", "pro drums", "part drums"]
+        fallbacks = ["drums", "part drums", "real drums", "part real drums"]
         out: List[mido.MidiTrack] = []
         for p in preferred:
             out = [tr for n, tr in names if n == p]
@@ -149,35 +158,50 @@ class RbMidiProcessor:
         return []
 
     def _collect_tempo_changes(self, mf: mido.MidiFile) -> List[Tuple[int, int]]:
-        changes: List[Tuple[int, int]] = []
+        changes: Dict[int, int] = {}
         for tr in mf.tracks:
             t = 0
             for msg in tr:
                 t += msg.time
-                if msg.is_meta and msg.type == "set_tempo":
-                    changes.append((t, int(msg.tempo)))
-        if not changes or changes[0][0] != 0:
-            changes.insert(0, (0, 500000))  # 120 BPM default at 0
-        changes.sort(key=lambda x: x[0])
-        return changes
+                if msg.is_meta and msg.type == "set_tempo" and t not in changes:
+                    changes[t] = int(msg.tempo)
+        if 0 not in changes:
+            changes[0] = 500000  # 120 BPM default at 0
+        return sorted(changes.items(), key=lambda x: x[0])
+
+    def _build_tempo_segments(
+        self, tempo_changes: List[Tuple[int, int]], tpq: int
+    ) -> Tuple[List[int], List[float], List[int]]:
+        ticks: List[int] = []
+        secs: List[float] = []
+        tempos: List[int] = []
+        sec = 0.0
+        last_tick = tempo_changes[0][0]
+        last_tempo = tempo_changes[0][1]
+        ticks.append(last_tick)
+        secs.append(0.0)
+        tempos.append(last_tempo)
+        for tick, tempo in tempo_changes[1:]:
+            sec += (tick - last_tick) * (last_tempo / 1_000_000.0) / tpq
+            ticks.append(tick)
+            secs.append(sec)
+            tempos.append(tempo)
+            last_tick = tick
+            last_tempo = tempo
+        return ticks, secs, tempos
+
+    def _tick_to_seconds(
+        self, tick: int, tempo_segments: Tuple[List[int], List[float], List[int]], tpq: int
+    ) -> float:
+        ticks, secs, tempos = tempo_segments
+        idx = bisect_right(ticks, tick) - 1
+        return secs[idx] + (tick - ticks[idx]) * (tempos[idx] / 1_000_000.0) / tpq
 
     def _tick_to_frame(
-        self, tick: int, tempo_changes: List[Tuple[int, int]], tpq: int
+        self, tick: int, tempo_segments: Tuple[List[int], List[float], List[int]], tpq: int
     ) -> int:
-        sec = 0.0
-        last_tick = 0
-        last_tempo = 500000
-        for t_tick, tempo in tempo_changes:
-            if t_tick > tick:
-                break
-            if t_tick > last_tick:
-                sec += (t_tick - last_tick) * (last_tempo / 1_000_000.0) / tpq
-                last_tick = t_tick
-            last_tempo = tempo
-        if tick > last_tick:
-            sec += (tick - last_tick) * (last_tempo / 1_000_000.0) / tpq
-        frame = int(sec * self.config.sample_rate / self.config.hop_length)
-        return frame
+        sec = self._tick_to_seconds(tick, tempo_segments, tpq)
+        return int(sec * self.config.sample_rate / self.config.hop_length)
 
     def _mark(
         self, label: torch.Tensor, frame: int, cls_key: str, max_frames: int
@@ -188,24 +212,6 @@ class RbMidiProcessor:
                 label[frame, idx] = 1.0
 
     # --- Event-level extraction for inventory/export ---
-    def _tick_to_seconds(
-        self, tick: int, tempo_changes: list[tuple[int, int]], tpq: int
-    ) -> float:
-        """Convert absolute tick to seconds using a tempo map (us_per_beat)."""
-        sec = 0.0
-        last_tick = 0
-        last_tempo = 500000  # default 120 BPM
-        for t_tick, tempo in tempo_changes:
-            if t_tick > tick:
-                break
-            if t_tick > last_tick:
-                sec += (t_tick - last_tick) * (last_tempo / 1_000_000.0) / tpq
-                last_tick = t_tick
-            last_tempo = tempo
-        if tick > last_tick:
-            sec += (tick - last_tick) * (last_tempo / 1_000_000.0) / tpq
-        return float(sec)
-
     def extract_events_per_difficulty(self, midi_path: Path) -> dict[str, Any] | None:
         """
         Parse a Rock Band/Clone Hero-style MIDI and return per-difficulty drum events.
@@ -225,11 +231,12 @@ class RbMidiProcessor:
             except TypeError:
                 mf = mido.MidiFile(midi_path)
         except Exception as e:
-            print(f"Warning: Could not read MIDI file {midi_path}: {e}")
+            logging.warning("Could not read MIDI file %s: %s", midi_path, e)
             return None
 
         tpq = mf.ticks_per_beat or 480
         tempo_map = self._collect_tempo_changes(mf)
+        tempo_segments = self._build_tempo_segments(tempo_map, tpq)
         drum_tracks = self._find_drum_tracks(mf)
         if not drum_tracks:
             drum_tracks = [mf.tracks[-1]]
@@ -249,22 +256,25 @@ class RbMidiProcessor:
         }
 
         # Per-note stacks (start_tick) for len_ticks calculation per difficulty/note
-        pending: dict[tuple[str, int], list[int]] = {}
+        pending: dict[tuple[str, int], deque[int]] = {}
 
-        # Cymbal toggles for Y/B/G pads (2/3/4)
-        cym_toggle: dict[int, bool] = {2: True, 3: True, 4: True}
+        # Cymbal toggles for Y/B/G pads (2/3/4) per difficulty
+        cym_toggle: dict[str, dict[int, bool]] = {
+            d: {2: True, 3: True, 4: True} for d in diffs
+        }
 
         for abs_tick, msg in events:
             if msg.type == "note_on" and msg.velocity > 0:
                 n = msg.note
-                # Cymbal toggles (global state)
+                # Cymbal toggles (apply to all difficulties)
                 if n in (110, 111, 112):
                     pad = {110: 2, 111: 3, 112: 4}[n]
-                    cym_toggle[pad] = not cym_toggle.get(pad, True)
+                    for state in cym_toggle.values():
+                        state[pad] = not state.get(pad, True)
                     continue
                 # Double kick note (map as kick on Expert)
                 if n == 95:
-                    t_sec = self._tick_to_seconds(abs_tick, tempo_map, tpq)
+                    t_sec = self._tick_to_seconds(abs_tick, tempo_segments, tpq)
                     out["Expert"]["events"].append(
                         {
                             "tick": int(abs_tick),
@@ -280,7 +290,7 @@ class RbMidiProcessor:
                 for dname, start in diffs.items():
                     if start <= n <= start + 5:
                         key = (dname, n)
-                        pending.setdefault(key, []).append(abs_tick)
+                        pending.setdefault(key, deque()).append(abs_tick)
                         break
             # Handle note_off or note_on with velocity 0 => close sustain
             elif (msg.type == "note_off") or (
@@ -292,7 +302,7 @@ class RbMidiProcessor:
                         key = (dname, n)
                         stack = pending.get(key)
                         if stack:
-                            on_tick = stack.pop(0)
+                            on_tick = stack.popleft()
                             pad = n - start  # 0..5
                             lane = pad
                             # Map to normalized hit
@@ -301,13 +311,13 @@ class RbMidiProcessor:
                             elif pad == 1:
                                 hit = "1"
                             elif pad in (2, 3, 4):
-                                if cym_toggle.get(pad, True):
+                                if cym_toggle[dname].get(pad, True):
                                     hit = {2: "66", 3: "67", 4: "68"}[pad]
                                 else:
                                     hit = {2: "2", 3: "3", 4: "4"}[pad]
                             else:  # pad == 5
                                 hit = "4"
-                            t_sec = self._tick_to_seconds(on_tick, tempo_map, tpq)
+                            t_sec = self._tick_to_seconds(on_tick, tempo_segments, tpq)
                             out[dname]["events"].append(
                                 {
                                     "tick": int(on_tick),
@@ -317,7 +327,7 @@ class RbMidiProcessor:
                                     "flags": {
                                         "cymbal": bool(
                                             pad in (2, 3, 4)
-                                            and cym_toggle.get(pad, True)
+                                            and cym_toggle[dname].get(pad, True)
                                         )
                                     },
                                     "len_ticks": int(abs_tick - on_tick),


### PR DESCRIPTION
## Summary
- Detect highest available drum difficulty and normalize track names
- Deduplicate tempo events and precompute segments for fast tick-to-time lookups
- Track cymbal toggles per difficulty and use deque for efficient sustain handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be36268f108323b06ff39e9fbd6d86