### PR TITLE
Ensure consistent tick-second conversions across modules

### DIFF
--- a/src/chart_hero/inference/chart_writer.py
+++ b/src/chart_hero/inference/chart_writer.py
@@ -6,6 +6,8 @@ from fractions import Fraction
 from pathlib import Path
 from typing import Iterable
 
+from chart_hero.utils.time_utils import seconds_to_ticks, ticks_to_seconds
+
 from .types import PredictionRow
 
 
@@ -31,13 +33,6 @@ class SongMeta:
     album: str | None = None
     year: str | int | None = None
     charter: str | None = "chart-hero"
-
-
-def seconds_to_ticks(seconds: float, bpm: float, resolution: int) -> int:
-    """Convert seconds to tick count using fractional math for precision."""
-    bpm_fraction = Fraction(str(bpm))
-    ticks_per_second = Fraction(resolution, 1) * bpm_fraction / 60
-    return round(Fraction(str(seconds)) * ticks_per_second)
 
 
 def write_chart(
@@ -117,7 +112,7 @@ def write_chart(
     track_lines.append("}")
 
     last_tick = max(tick_to_notes, default=0)
-    song_length_seconds = float(Fraction(last_tick, 1) / ticks_per_second)
+    song_length_seconds = ticks_to_seconds(last_tick, bpm, resolution)
 
     chart_text = "\n".join(song_lines + sync_lines + events_lines + track_lines) + "\n"
     (out_dir / "notes.chart").write_text(chart_text, encoding="utf-8")

--- a/src/chart_hero/inference/mid_export.py
+++ b/src/chart_hero/inference/mid_export.py
@@ -17,10 +17,7 @@ import mido
 
 from chart_hero.inference.mid_vocals import SyllableEvent, Phrase
 from chart_hero.inference.types import PredictionRow
-
-
-def seconds_to_ticks(seconds: float, bpm: float, ppq: int) -> int:
-    return int(round(seconds * (ppq * bpm / 60.0)))
+from chart_hero.utils.time_utils import seconds_to_ticks
 
 
 def _add_vocals_track(
@@ -115,13 +112,11 @@ def _add_drums_track(
     gem_dur = max(1, int(round(ppq * 0.125)))  # ~1/8 note
     tog_dur = 1
 
-    samp_to_tick = (ppq * bpm / 60.0) / float(sr)
-
     for row in rows:
         peak = row.get("peak_sample")
         if peak is None:
             continue
-        tick = int(round(int(peak) * samp_to_tick))
+        tick = seconds_to_ticks(int(peak) / sr, bpm, ppq)
 
         # Determine desired cymbal state per pad at this tick
         # Correct color mapping:

--- a/src/chart_hero/inference/mid_vocals.py
+++ b/src/chart_hero/inference/mid_vocals.py
@@ -14,6 +14,8 @@ from typing import Iterable, List, Optional, Sequence
 
 import mido
 
+from chart_hero.utils.time_utils import seconds_to_ticks
+
 
 @dataclass
 class SyllableEvent:
@@ -26,10 +28,6 @@ class SyllableEvent:
 class Phrase:
     t0: float
     t1: float
-
-
-def seconds_to_ticks(seconds: float, bpm: float, ppq: int) -> int:
-    return int(round(seconds * (ppq * bpm / 60.0)))
 
 
 def write_vocals_midi(

--- a/src/chart_hero/utils/time_utils.py
+++ b/src/chart_hero/utils/time_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Utility functions for converting between seconds and MIDI ticks.
+
+These helpers centralize the tick/second conversions so that timing math
+remains consistent across modules.
+"""
+
+from fractions import Fraction
+
+
+def seconds_to_ticks(seconds: float, bpm: float, resolution: int) -> int:
+    """Convert seconds to MIDI ticks using fractional math for precision."""
+    bpm_fraction = Fraction(str(bpm))
+    ticks_per_second = Fraction(resolution, 1) * bpm_fraction / 60
+    return round(Fraction(str(seconds)) * ticks_per_second)
+
+
+def ticks_to_seconds(ticks: int, bpm: float, resolution: int) -> float:
+    """Convert MIDI ticks to seconds using fractional math for precision."""
+    bpm_fraction = Fraction(str(bpm))
+    seconds_per_tick = Fraction(60, 1) / (Fraction(resolution, 1) * bpm_fraction)
+    return float(Fraction(ticks, 1) * seconds_per_tick)


### PR DESCRIPTION
## Summary
- add `time_utils` to handle seconds/ticks conversions in one place
- update chart writer and MIDI exporters to use shared helpers
- compute song lengths with precise tick-to-second math

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be3a70b8bc83239516b0cbe834922d