### PR TITLE
Skip MIDI files lacking drum charts

### DIFF
--- a/src/chart_hero/train/build_dataset.py
+++ b/src/chart_hero/train/build_dataset.py
@@ -242,7 +242,10 @@ def normalize_loudness_rms(y: np.ndarray, target_dbfs: float = -14.0) -> np.ndar
 def build_labels_from_midi(
     midi_path: Path, num_time_frames: int, processor: RbMidiProcessor
 ) -> Optional[torch.Tensor]:
-    return processor.create_label_matrix(midi_path, num_time_frames)
+    labels = processor.create_label_matrix(midi_path, num_time_frames)
+    if labels is None or not torch.any(labels):
+        return None
+    return labels
 
 
 # --- .chart/.txt support ---

--- a/tests/train/test_build_dataset.py
+++ b/tests/train/test_build_dataset.py
@@ -1,0 +1,20 @@
+import mido
+
+from chart_hero.train.build_dataset import build_labels_from_midi
+from chart_hero.utils.rb_midi_utils import RbMidiProcessor
+from chart_hero.model_training.transformer_config import get_config
+
+
+def test_build_labels_from_midi_returns_none_without_drums(tmp_path):
+    midi_path = tmp_path / "nondrum.mid"
+    mid = mido.MidiFile()
+    track = mido.MidiTrack()
+    track.append(mido.Message("note_on", note=40, velocity=64, time=0))
+    track.append(mido.Message("note_off", note=40, velocity=64, time=480))
+    mid.tracks.append(track)
+    mid.save(midi_path)
+
+    config = get_config("local")
+    processor = RbMidiProcessor(config)
+    labels = build_labels_from_midi(midi_path, num_time_frames=100, processor=processor)
+    assert labels is None


### PR DESCRIPTION
## Summary
- ensure `build_labels_from_midi` returns `None` when MIDI charts contain no drum hits
- add regression test for drumless MIDI files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be4058d0dc8323b70e24726f73b87e