### PR TITLE
Avoid parsing non-drum tracks in MIDI processors

### DIFF
--- a/tests/utils/test_midi_utils.py
+++ b/tests/utils/test_midi_utils.py
@@ -1,6 +1,4 @@
-"""
-Tests for the MidiProcessor in utils/midi_utils.py.
-"""
+"""Tests for the MidiProcessor in utils/midi_utils.py."""
 
 import mido
 import pytest
@@ -29,20 +27,48 @@ def dummy_midi_file(tmp_path):
     track = mido.MidiTrack()
     mid.tracks.append(track)
 
+    track.append(mido.MetaMessage("track_name", name="Drums"))
     track.append(mido.MetaMessage("set_tempo", tempo=500000, time=0))
-    track.append(mido.Message("note_on", note=36, velocity=64, time=480))  # Kick
-    track.append(mido.Message("note_on", note=38, velocity=64, time=480))  # Snare
+    track.append(mido.Message("note_on", note=36, velocity=64, time=480, channel=9))  # Kick
+    track.append(mido.Message("note_on", note=38, velocity=64, time=480, channel=9))  # Snare
     mid_path = tmp_path / "dummy.mid"
     mid.save(str(mid_path))
     return mid_path
 
 
+@pytest.fixture
+def no_drum_midi_file(tmp_path):
+    """Creates a MIDI file with no drum track."""
+    mid = mido.MidiFile()
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+
+    track.append(mido.MetaMessage("track_name", name="Piano"))
+    track.append(mido.MetaMessage("set_tempo", tempo=500000, time=0))
+    track.append(mido.Message("note_on", note=100, velocity=64, time=480, channel=0))
+    mid_path = tmp_path / "nodrum.mid"
+    mid.save(str(mid_path))
+    return mid_path
+
+
 def test_create_label_matrix(midi_processor, dummy_midi_file, config):
-    """Test the create_label_matrix method."""
+    """Drum track is parsed into non-empty label matrix."""
     num_time_frames = int(2 * config.sample_rate / config.hop_length)  # 2 seconds
     label_matrix = midi_processor.create_label_matrix(dummy_midi_file, num_time_frames)
 
     assert isinstance(label_matrix, torch.Tensor)
     assert label_matrix.shape == (num_time_frames, config.num_drum_classes)
     assert torch.sum(label_matrix) > 0  # Check that some notes were found
-    assert torch.sum(label_matrix) > 0  # Check that some notes were found
+
+
+def test_no_drum_track_returns_empty_labels(
+    midi_processor, no_drum_midi_file, config
+):
+    """MIDIs without drum tracks yield an all-zero label matrix."""
+    num_time_frames = int(2 * config.sample_rate / config.hop_length)
+    label_matrix = midi_processor.create_label_matrix(no_drum_midi_file, num_time_frames)
+
+    assert isinstance(label_matrix, torch.Tensor)
+    assert label_matrix.shape == (num_time_frames, config.num_drum_classes)
+    assert torch.count_nonzero(label_matrix) == 0
+

--- a/tests/utils/test_rb_midi_utils.py
+++ b/tests/utils/test_rb_midi_utils.py
@@ -33,3 +33,22 @@ def test_rb_midi_processor_on_rb2_mid(config):
     assert labels.shape == (frames, config.num_drum_classes)
     # Expect some drum content
     assert torch.sum(labels) > 0
+
+
+def test_rb_midi_processor_no_drum_track(config):
+    """RbMidiProcessor should yield no events when a MIDI lacks a drum track."""
+    midi_path = Path(
+        "honest-bob-and-the-factory-to-dealer-incentives/soy-bomb/notes.mid"
+    )
+    if not midi_path.exists():
+        pytest.skip(f"Test MIDI not found at {midi_path}")
+
+    proc = RbMidiProcessor(config)
+    frames = 1000
+    labels = proc.create_label_matrix(midi_path, frames)
+    assert torch.sum(labels) == 0
+
+    evdoc = proc.extract_events_per_difficulty(midi_path)
+    assert evdoc is not None
+    for diff in ("Easy", "Medium", "Hard", "Expert"):
+        assert evdoc["difficulties"][diff]["events"] == []


### PR DESCRIPTION
## Summary
- Do not fall back to parsing non-drum tracks in `RbMidiProcessor`
- Guard `MidiProcessor` by detecting drum tracks and returning empty labels when none found
- Add regression tests for MIDIs lacking drum parts across both RB and GM formats

## Testing
- `pytest`
- `PYTHONPATH=src python - <<'PY'
from chart_hero.model_training.transformer_config import get_config
from chart_hero.utils.rb_midi_utils import RbMidiProcessor
from chart_hero.utils.midi_utils import MidiProcessor
from pathlib import Path
import mido, tempfile

config = get_config('local')
rb_proc = RbMidiProcessor(config)
path = Path('honest-bob-and-the-factory-to-dealer-incentives/soy-bomb/notes.mid')
evdoc = rb_proc.extract_events_per_difficulty(path)
print({diff: len(evdoc['difficulties'][diff]['events']) for diff in evdoc['difficulties']})

# Demonstrate MidiProcessor handling of a MIDI without drums
proc = MidiProcessor(config)
mid = mido.MidiFile()
tr = mido.MidiTrack(); mid.tracks.append(tr)
tr.append(mido.MetaMessage('track_name', name='Piano'))
tr.append(mido.MetaMessage('set_tempo', tempo=500000))
tr.append(mido.Message('note_on', note=100, velocity=64, time=480, channel=0))
fd, tmp = tempfile.mkstemp(suffix='.mid'); Path(tmp).unlink(); mid.save(tmp)
label = proc.create_label_matrix(Path(tmp), 100)
print('non_drum_sum', label.sum().item())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68be4bc5ad388323acdcb1e019580b2f