### PR TITLE
Add tempo mapping evaluation script

### DIFF
--- a/scripts/eval_tempo_map.py
+++ b/scripts/eval_tempo_map.py
@@ -144,10 +144,17 @@ def main() -> None:
             res = evaluate_song(entry.path)
             if res:
                 results.append(res)
-                print(
-                    f"{res['song']}: BPM err={res['avg_bpm_error']:.2f} "
-                    f"Boundary err={res['avg_boundary_error']:.3f}s"
+                bpm_err = (
+                    f"{res['avg_bpm_error']:.2f}"
+                    if res["avg_bpm_error"] is not None
+                    else "N/A"
                 )
+                boundary_err = (
+                    f"{res['avg_boundary_error']:.3f}s"
+                    if res["avg_boundary_error"] is not None
+                    else "N/A"
+                )
+                print(f"{res['song']}: BPM err={bpm_err} Boundary err={boundary_err}")
 
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- add utility to extract tempo segments from Clone Hero charts
- compare chart tempos against audio-based tempo mapping
- skip formatting when evaluation metrics are missing to prevent crashes

## Testing
- `pytest` *(fails: tests/utils/test_tempo_real_audio.py::test_estimate_tempo_map_with_real_audio[tempo_3tempo_test_track.wav-bpms1-times1-0.05] - assert 0.3544671201814058 < 0.05, tests/utils/test_tempo_real_audio.py::test_estimate_tempo_map_with_real_audio[tempo_4tempo_test_track.wav-bpms2-times2-0.05] - assert 0.3544671201814058 < 0.05, tests/utils/test_tempo_real_audio.py::test_estimate_tempo_map_with_real_audio[tempo_5tempo_test_track.wav-bpms3-times3-0.05] - assert 0.3544671201814058 < 0.05)*

------
https://chatgpt.com/codex/tasks/task_e_68c06b7633f88323a54403f22fb342a8