### PR TITLE
Refine leading silence trimming and timing alignment

### DIFF
--- a/src/chart_hero/inference/inference_utils.py
+++ b/src/chart_hero/inference/inference_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Sequence
+
+import numpy as np
 
 
 def map_patch_to_sample(
@@ -19,3 +21,32 @@ def map_patch_to_sample(
     if add_ms:
         sample += int(add_ms * sample_rate / 1000.0)
     return int(sample)
+
+
+def estimate_global_shift(
+    energy: np.ndarray,
+    pred_frames: Sequence[int],
+    hop_length: int,
+    sample_rate: int,
+    max_shift_ms: float = 200.0,
+) -> float:
+    """Estimate global time shift via cross-correlation (ms)."""
+    if energy.size == 0 or not pred_frames:
+        return 0.0
+    N = energy.size
+    pred = np.zeros(N, dtype=float)
+    for f in pred_frames:
+        if 0 <= f < N:
+            pred[f] += 1.0
+    energy_z = energy - energy.mean()
+    pred_z = pred - pred.mean()
+    corr = np.correlate(energy_z, pred_z, mode="full")
+    lags = np.arange(-N + 1, N)
+    max_shift_frames = int(round(max_shift_ms * sample_rate / (hop_length * 1000.0)))
+    center = N - 1
+    start = max(0, center - max_shift_frames)
+    end = min(corr.size, center + max_shift_frames + 1)
+    window = corr[start:end]
+    lwindow = lags[start:end]
+    best_lag = int(lwindow[np.argmax(window)])
+    return best_lag * hop_length * 1000.0 / sample_rate

--- a/src/chart_hero/inference/types.py
+++ b/src/chart_hero/inference/types.py
@@ -27,3 +27,6 @@ class TransformerConfig(Protocol):
     class_thresholds: list[float] | None
     device: str
     inference_batch_size: int
+    leading_silence_db: float
+    leading_silence_min_ms: float
+    global_shift_max_ms: float

--- a/src/chart_hero/model_training/transformer_config.py
+++ b/src/chart_hero/model_training/transformer_config.py
@@ -162,6 +162,9 @@ class BaseConfig:
 
     # Inference settings
     inference_batch_size: int = 4
+    leading_silence_db: float = -40.0
+    leading_silence_min_ms: float = 250.0
+    global_shift_max_ms: float = 200.0
 
     # Data
     train_batch_size: int = 32

--- a/tests/inference/test_charter_offsets.py
+++ b/tests/inference/test_charter_offsets.py
@@ -1,0 +1,53 @@
+import numpy as np
+import torch
+
+from chart_hero.inference.charter import Charter
+from chart_hero.model_training.transformer_config import get_config, get_drum_hits
+
+
+def test_charter_predict_offsets(monkeypatch):
+    config = get_config("local")
+    config.patch_stride = config.patch_size[0]
+    dummy_base = torch.nn.Module()
+    monkeypatch.setattr(
+        "chart_hero.inference.charter.load_model_from_checkpoint",
+        lambda cfg, path, max_time_patches=None: dummy_base,
+    )
+    charter = Charter(config, "dummy_model.ckpt")
+
+    class Dummy(torch.nn.Module):
+        def __init__(self, C):
+            super().__init__()
+            self.C = C
+        def forward(self, x):
+            B = x.shape[0]
+            logits = torch.full((B, 1, self.C), -10.0)
+            logits[:, 0, 0] = 10.0
+            return {"logits": logits}
+
+    charter.model = Dummy(len(get_drum_hits()))
+
+    fps = config.sample_rate / config.hop_length
+    offset_frames = int(1 * fps)
+    n_mels = config.n_mels
+    patch = config.patch_size[0]
+    segs = [
+        {
+            "spec": np.zeros((n_mels, offset_frames)),
+            "start_frame": 0,
+            "end_frame": offset_frames,
+            "total_frames": offset_frames + patch,
+        },
+        {
+            "spec": np.ones((n_mels, patch)),
+            "start_frame": offset_frames,
+            "end_frame": offset_frames + patch,
+            "total_frames": offset_frames + patch,
+        },
+    ]
+
+    df = charter.predict(segs)
+    assert charter.last_offset_samples == offset_frames * config.hop_length
+    assert not df.empty
+    first = int(df.iloc[0]["peak_sample"])
+    assert first >= charter.last_offset_samples

--- a/tests/inference/test_segment_utils.py
+++ b/tests/inference/test_segment_utils.py
@@ -25,7 +25,7 @@ def test_detect_leading_silence():
     }
 
     frames = detect_leading_silence_from_segments(
-        [seg_silence, seg_sound], threshold=0.1
+        [seg_silence, seg_sound], threshold_db=-20.0
     )
     seconds = frames * config.hop_length / config.sample_rate
     assert seconds == pytest.approx(5.0, abs=0.1)


### PR DESCRIPTION
## Summary
- use relative energy to detect and trim leading silence, exposing threshold and minimum duration in config
- estimate global time shift via cross-correlation and adjust predictions
- report applied lead-in and shift in offset analysis
- add tests for updated silence detector and charter offset handling

## Testing
- `pytest -q`
- `PYTHONPATH=src python scripts/analyze_offsets.py --model models/local_transformer_models/20250908_203931/last.ckpt --roots CloneHero/KnownGoodSongs --nms-k 9 --activity-gate 0.45 --patch-stride 1 --tol-ms 45` *(fails: No songs with notes.mid + audio found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0932531908323837e0d7f09b110ad