### PR TITLE
Refine leading silence trimming and timing alignment

### DIFF
--- a/src/chart_hero/inference/charter.py
+++ b/src/chart_hero/inference/charter.py
@@ -489,7 +489,7 @@ class Charter:
             if shift_ms:
                 shift_samples = int(round(shift_ms * self.config.sample_rate / 1000.0))
                 for r in rows:
-                    r["peak_sample"] = r["peak_sample"] - shift_samples
+                    r["peak_sample"] = r["peak_sample"] + shift_samples
                 rows = [r for r in rows if r["peak_sample"] >= 0]
 
         if not rows:

--- a/tests/inference/test_charter_offsets.py
+++ b/tests/inference/test_charter_offsets.py
@@ -50,4 +50,5 @@ def test_charter_predict_offsets(monkeypatch):
     assert charter.last_offset_samples == offset_frames * config.hop_length
     assert not df.empty
     first = int(df.iloc[0]["peak_sample"])
-    assert first >= charter.last_offset_samples
+    shift_samples = int(round(charter.last_shift_ms * config.sample_rate / 1000.0))
+    assert first >= charter.last_offset_samples + shift_samples


### PR DESCRIPTION
## Summary
- apply cross-correlation shift with correct sign
- update offset test expectations for signed shift

## Testing
- `pre-commit run --files src/chart_hero/inference/charter.py tests/inference/test_charter_offsets.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest tests/inference/test_charter.py tests/inference/test_charter_offsets.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f34370648323991c2cef6c2a57b0