### PR TITLE
fix: sync sliding-window jitter across dataloader workers

### DIFF
--- a/src/chart_hero/model_training/train_transformer.py
+++ b/src/chart_hero/model_training/train_transformer.py
@@ -209,10 +209,14 @@ def main() -> None:
             except Exception:
                 pass
 
+        shared_epoch = mp.Value("i", 0)
         logger.info("Creating data loaders...")
         try:
             train_loader, val_loader, test_loader = create_data_loaders(
-                config=config, data_dir=config.data_dir, with_lengths=True
+                config=config,
+                data_dir=config.data_dir,
+                with_lengths=True,
+                shared_epoch=shared_epoch,
             )
         except Exception as e:
             msg = str(e)
@@ -231,7 +235,10 @@ def main() -> None:
                 setattr(config, "num_workers", 0)
                 setattr(config, "persistent_workers", False)
                 train_loader, val_loader, test_loader = create_data_loaders(
-                    config=config, data_dir=config.data_dir, with_lengths=True
+                    config=config,
+                    data_dir=config.data_dir,
+                    with_lengths=True,
+                    shared_epoch=shared_epoch,
                 )
             else:
                 raise
@@ -248,14 +255,19 @@ def main() -> None:
         callbacks = setup_callbacks(config, use_logger=use_wandb)
         # Ensure sliding-window datasets update window positions each epoch
         class DatasetEpochCallback(Callback):
-            def __init__(self, dataset):
-                self.dataset = dataset
+            def __init__(self, loader, shared_epoch):
+                self.loader = loader
+                self.shared_epoch = shared_epoch
 
             def on_train_epoch_start(self, trainer, pl_module):
-                if hasattr(self.dataset, "set_epoch"):
-                    self.dataset.set_epoch(trainer.current_epoch)
+                epoch = trainer.current_epoch
+                self.shared_epoch.value = epoch
+                if self.loader.num_workers == 0 and hasattr(
+                    self.loader.dataset, "set_epoch"
+                ):
+                    self.loader.dataset.set_epoch(epoch)
 
-        callbacks.append(DatasetEpochCallback(train_loader.dataset))
+        callbacks.append(DatasetEpochCallback(train_loader, shared_epoch))
         trainer_kwargs["callbacks"] = callbacks
 
         # Log final checkpoint settings and model_dir


### PR DESCRIPTION
## Summary
- share current epoch across loader workers and refresh sliding-window indices lazily
- update training loop to broadcast epoch changes to workers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1e2542b6c83238733eb5f36573911