### PR TITLE
fix: preserve boundary events during window weighting

### DIFF
--- a/src/chart_hero/inference/charter.py
+++ b/src/chart_hero/inference/charter.py
@@ -307,10 +307,11 @@ class Charter:
                     weight = self._window_weight(
                         int(seg["start_frame"]), int(seg["end_frame"]), int(frame_idx)
                     )
-                    p_t = seg_probs[t] * weight  # [C]
+                    raw_p_t = seg_probs[t]  # [C]
+                    p_t = raw_p_t * weight
                     km_t = keep_mask[t]
-                    # Binary activations by threshold
-                    act = (p_t >= thr_row) & km_t
+                    # Binary activations by threshold before weighting
+                    act = (raw_p_t >= thr_row) & km_t
 
                     # Local frame index inside spectrogram
                     local_idx = min(
@@ -326,7 +327,7 @@ class Charter:
                     # Optional onset gate: require onset probability >= threshold
                     if onset_probs is not None:
                         try:
-                            if float(onset_probs[b_idx, t].item() * weight) < float(onset_thr):
+                            if float(onset_probs[b_idx, t].item()) < float(onset_thr):
                                 continue
                         except Exception:
                             pass

--- a/tests/inference/test_charter.py
+++ b/tests/inference/test_charter.py
@@ -75,3 +75,20 @@ def test_window_weight_function():
     assert Charter._window_weight(0, 100, 50) == 1.0
     assert Charter._window_weight(0, 100, 0) == 0.0
     assert pytest.approx(Charter._window_weight(0, 100, 75), 0.01) == 0.5
+
+
+def test_boundary_weighting_does_not_suppress_hits():
+    """Ensure thresholding occurs before window weighting."""
+    weight = Charter._window_weight(0, 100, 0)
+    assert weight == 0.0
+    seg_probs = torch.tensor([[1.0]])
+    thr_row = torch.tensor([0.5])
+    km_t = torch.tensor([True])
+
+    p_t = seg_probs[0] * weight
+    act_old = (p_t >= thr_row) & km_t
+    assert not bool(act_old.item())
+
+    raw_p_t = seg_probs[0]
+    act_new = (raw_p_t >= thr_row) & km_t
+    assert bool(act_new.item())


### PR DESCRIPTION
## Summary
- apply thresholding before window weighting to keep boundary detections
- drop weighting from onset gate and add regression test

## Testing
- `pytest`
- `pre-commit run --files src/chart_hero/inference/charter.py tests/inference/test_charter.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e85e50c48323958edc164b786dd0