### PR TITLE
feat: add window length configuration

### DIFF
--- a/src/chart_hero/model_training/training_setup.py
+++ b/src/chart_hero/model_training/training_setup.py
@@ -124,8 +124,10 @@ def setup_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--max-audio-length",
+        "--window-length",
+        dest="max_audio_length",
         type=float,
-        help="Override max audio segment length in seconds for training windows",
+        help="Override sliding window length in seconds",
     )
     return parser
 
@@ -176,7 +178,7 @@ def apply_cli_overrides(config: "BaseConfig", args: argparse.Namespace) -> None:
         config.enable_media_logging = True
     if getattr(args, "max_audio_length", None) is not None:
         try:
-            config.max_audio_length = float(args.max_audio_length)
+            config.set_window_length(float(args.max_audio_length))
         except Exception:
             pass
 

--- a/src/chart_hero/model_training/transformer_data.py
+++ b/src/chart_hero/model_training/transformer_data.py
@@ -232,9 +232,12 @@ class SlidingWindowDataset(Dataset[Tuple[torch.Tensor, torch.Tensor]]):
         self.shared_epoch = shared_epoch
 
         max_seq_len = int(getattr(self.config, "max_seq_len", 0) or 0)
+        window_seconds = getattr(self.config, "window_length_seconds", None)
+        if window_seconds is None:
+            window_seconds = float(getattr(self.config, "max_audio_length", 0.0) or 0.0)
         max_audio_frames = int(
             round(
-                (getattr(self.config, "max_audio_length", 0.0) or 0.0)
+                window_seconds
                 * self.config.sample_rate
                 / max(1, int(self.config.hop_length))
             )

--- a/tests/inference/test_input_transform.py
+++ b/tests/inference/test_input_transform.py
@@ -44,7 +44,7 @@ def test_audio_to_tensors(dummy_audio_file):
 
 def test_audio_to_tensors_overlap(dummy_audio_file):
     config = get_config("local")
-    config.max_audio_length = 5.0
+    config.set_window_length(5.0)
     config.inference_overlap_ratio = 0.25
     segments = audio_to_tensors(str(dummy_audio_file), config)
     assert len(segments) >= 2

--- a/tests/model_training/test_sliding_window_dataset.py
+++ b/tests/model_training/test_sliding_window_dataset.py
@@ -18,8 +18,7 @@ def _create_dummy_pair(tmp_path, config, length):
 
 def test_validation_windows_deterministic(tmp_path):
     config = get_config("local")
-    config.max_seq_len = 40
-    config.max_audio_length = 40 * config.hop_length / config.sample_rate
+    config.set_window_length(40 * config.hop_length / config.sample_rate)
     pairs = _create_dummy_pair(tmp_path, config, length=100)
     dataset = SlidingWindowDataset(pairs, config, mode="val")
     assert len(dataset) == 4
@@ -32,8 +31,7 @@ def test_validation_windows_deterministic(tmp_path):
 
 def test_training_windows_change_with_epoch(tmp_path):
     config = get_config("local")
-    config.max_seq_len = 40
-    config.max_audio_length = 40 * config.hop_length / config.sample_rate
+    config.set_window_length(40 * config.hop_length / config.sample_rate)
     config.window_jitter_ratio = 0.5
     pairs = _create_dummy_pair(tmp_path, config, length=120)
     dataset = SlidingWindowDataset(pairs, config, mode="train")

--- a/tests/model_training/test_window_length_config.py
+++ b/tests/model_training/test_window_length_config.py
@@ -1,0 +1,15 @@
+from chart_hero.model_training.transformer_config import get_config
+
+def test_set_window_length_adjusts_seq_len_and_batch():
+    config = get_config("local")
+    base_train = config.train_batch_size
+    base_val = config.val_batch_size
+    frames_per_sec = config.sample_rate / config.hop_length
+
+    config.set_window_length(30.0)
+
+    assert config.max_audio_length == 30.0
+    assert config.window_length_seconds == 30.0
+    assert config.max_seq_len == int(30.0 * frames_per_sec)
+    assert config.train_batch_size == max(1, int(base_train * 20.0 / 30.0))
+    assert config.val_batch_size == max(1, int(base_val * 20.0 / 30.0))


### PR DESCRIPTION
## Summary
- expose sliding-window fields in config and add `set_window_length` helper to auto-scale sequence length and batch size
- wire up `--window-length` CLI option and dataset support for custom window sizes
- add regression tests for window length handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e9fe680083238be4c0ab71a9dcf2