### PR TITLE
feat: add window length configuration

### DIFF
--- a/tests/model_training/test_window_length_config.py
+++ b/tests/model_training/test_window_length_config.py
@@ -13,3 +13,11 @@ def test_set_window_length_adjusts_seq_len_and_batch():
     assert config.max_seq_len == int(30.0 * frames_per_sec)
     assert config.train_batch_size == max(1, int(base_train * 20.0 / 30.0))
     assert config.val_batch_size == max(1, int(base_val * 20.0 / 30.0))
+
+
+def test_cloud_config_window_length_override():
+    config = get_config("cloud", max_audio_length=30.0)
+    frames_per_sec = config.sample_rate / config.hop_length
+    assert config.max_audio_length == 30.0
+    assert config.window_length_seconds == 30.0
+    assert config.max_seq_len == int(30.0 * frames_per_sec)


### PR DESCRIPTION
## Summary
- expose sliding-window fields in config and add `set_window_length` helper to auto-scale sequence length and batch size
- wire up `--window-length` CLI option and dataset support for custom window sizes
- add regression tests for window length handling
- define `set_window_length` on `BaseConfig` so cloud configs respect `max_audio_length`

## Testing
- `python3 -m py_compile src/chart_hero/model_training/transformer_config.py tests/model_training/test_window_length_config.py`
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ecd19ff08323aceee9ae767b55a6